### PR TITLE
Fix memory leak in COMPUTE_JARO

### DIFF
--- a/ext/amatch.c
+++ b/ext/amatch.c
@@ -690,7 +690,10 @@ static VALUE LongestSubstring_similar(General *amatch, VALUE string)
         }                                                                           \
         t = t / 2;                                                                  \
         result = (((double)m)/a_len + ((double)m)/b_len + ((double)(m-t))/m)/3.0;   \
-    }
+    }                                                                               \
+    free(l[0]);                                                                     \
+    free(l[1]);
+
 
 #define LOWERCASE_STRINGS                                       \
      char *ying = ALLOC_N(char, a_len);                         \


### PR DESCRIPTION
Hi Flori,

Amatch is great; I just used it on a big dataset and found a memory leak in the COMPUTE_JARO routine. The fix is simple, as you can see.

best,

Kevin
