### PR TITLE
Fix issue in jaro distance where a match score of 0.0 was returned when two identical strings of length 1 were compared

### DIFF
--- a/ext/amatch_ext.c
+++ b/ext/amatch_ext.c
@@ -791,7 +791,7 @@ static VALUE LongestSubstring_similar(General *amatch, VALUE string)
     }                                                                               \
     if (m == 0) {                                                                   \
         if(a_len == b_len && a_len == 1 && a_ptr[0] == b_ptr[0]) {                  \
-            result = 1.0;                                                             \
+            result = 1.0;                                                           \
         } else {                                                                    \
             result = 0.0;                                                           \
         }                                                                           \

--- a/ext/amatch_ext.c
+++ b/ext/amatch_ext.c
@@ -790,7 +790,11 @@ static VALUE LongestSubstring_similar(General *amatch, VALUE string)
         }                                                                           \
     }                                                                               \
     if (m == 0) {                                                                   \
-        result = 0.0;                                                               \
+        if(a_len == b_len && a_len == 1 && a_ptr[0] == b_ptr[0]) {                  \
+            result = 1.0;                                                             \
+        } else {                                                                    \
+            result = 0.0;                                                           \
+        }                                                                           \
     } else {                                                                        \
         k = t = 0;                                                                  \
         for (i = 0; i < a_len; i++) {                                               \

--- a/tests/test_jaro.rb
+++ b/tests/test_jaro.rb
@@ -11,6 +11,7 @@ class TestJaro < Test::Unit::TestCase
     @dwayne = Jaro.new('dwayne')
     @dixon  = Jaro.new('DIXON')
     @one    = Jaro.new('one')
+    @single = Jaro.new('a')
   end
 
   def test_case
@@ -25,5 +26,6 @@ class TestJaro < Test::Unit::TestCase
     assert_in_delta 0.822, @dwayne.match('DUANE'), D
     assert_in_delta 0.767, @dixon.match('DICKSONX'), D
     assert_in_delta 0.667, @one.match('orange'), D
+    assert_in_delta 1.0, @single.match('a')
   end
 end

--- a/tests/test_jaro_winkler.rb
+++ b/tests/test_jaro_winkler.rb
@@ -11,6 +11,7 @@ class TestJaroWinkler < Test::Unit::TestCase
     @dwayne = JaroWinkler.new('dwayne')
     @dixon  = JaroWinkler.new('DIXON')
     @one    = JaroWinkler.new("one")
+    @single = JaroWinkler.new("a")
   end
 
   def test_case
@@ -26,6 +27,7 @@ class TestJaroWinkler < Test::Unit::TestCase
     assert_in_delta 0.813, @dixon.match('DICKSONX'), D
     assert_in_delta 0, @one.match('two'), D
     assert_in_delta 0.700, @one.match('orange'), D
+    assert_in_delta 1.0, @single.match("a")
   end
 
   def test_scaling_factor


### PR DESCRIPTION
 - When comparing single character strings with Jaro a score of 0.0 is always returned, even if the strings match.

```rb
matcher = Amatch::Jaro.new('a')
matcher.match('a')
# => 0.0
matcher.match('b')
# => 0.0
```

- When comparing single character strings with Jaro-Winkler a score of 0.1 is returned if the strings match and 0.0 if they don't

```rb
matcher = Amatch::JaroWinkler.new('a')
matcher.match('a')
# => 0.1
matcher.match('b')
# => 0.0
```

I wrote tests for both matchers, though the issue was at the Jaro match level.
